### PR TITLE
v0.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "streamlit-card" %}
+{% set version = "0.0.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit-card-{{ version }}.tar.gz
+  sha256: 5fe81450310f1e2b6660c83eb6d82f1a5b671d5d42b5e46b3bc654120c481a2c
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  skip: true  # [py<38]
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - streamlit >=0.63
+
+test:
+  imports:
+    - streamlit_card
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/gamcoh/st-card
+  dev_url: https://github.com/gamcoh/st-card
+  doc_url: https://github.com/gamcoh/st-card/blob/v0.0.4/README.md
+  summary: A streamlit component, to make UI cards
+  description: |
+    A streamlit component, to make UI cards
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - ELundby45

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [py<38]
+  # s390x is missing streamlit
+  skip: true  # [py<38 or s390x]
 
 requirements:
   host:


### PR DESCRIPTION
upstream: https://github.com/gamcoh/st-card

`streamlit-extras` -> `streamlit-card`

## Notes
- Upstream has a bogus `requirements` file that isn't used. 
- This is a brand new feedstock
- s390x is skipped dud to no availability of `streamlit`
- This is for Snowflake